### PR TITLE
Dependency function now checks if geometry is already a target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,33 @@ find_package(yaml-cpp REQUIRED)
 function(find_deps package url)
     find_package(${package} QUIET)
     if (${package}_FOUND)
-        message(STATUS found ${package})
+        message(STATUS "${PROJECT_NAME} found package ${package}")
+    elseif(TARGET ${package})
+        if(EXISTS ${CMAKE_SOURCE_DIR}/lib/${package})
+            message(STATUS 
+                "${PROJECT_NAME} found ${package} in ${CMAKE_SOURCE_DIR}/lib/")
+            set(${package}_INCLUDE_DIRS
+                ${CMAKE_SOURCE_DIR}/lib/${package}/include PARENT_SCOPE)
+        else()
+            message(STATUS 
+                "${PROJECT_NAME} could not find existing ${package} TARGET")
+        endif()
+    elseif(EXISTS ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        message(STATUS 
+            "${PROJECT_NAME} found ${package} in ${PROJECT_NAME}/lib/")
+        add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        set(${package}_INCLUDE_DIRS 
+            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
     else()
-        message(STATUS "did not find ${package}, cloning into local lib/ folder")
+        message(STATUS "${PROJECT_NAME} did not find ${package}")
+        message(STATUS "cloning ${package} into local ${PROJECT_NAME}/lib/")
         # Clone and create the proper variables
         file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/lib)
-        execute_process(COMMAND git clone ${url} ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        execute_process(COMMAND 
+            git clone ${url} ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
         add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        set(${package}_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include)
+        set(${package}_INCLUDE_DIRS 
+            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
     endif()
 endfunction()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,47 +8,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 find_package(Eigen3 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-function(find_deps package url)
-    find_package(${package} QUIET)
-    if (${package}_FOUND)
-        message(STATUS "${PROJECT_NAME} found package ${package}")
-    elseif(TARGET ${package})
-        string(LENGTH ${CMAKE_CURRENT_SOURCE_DIR} cur_src_len)
-        string(LENGTH "/lib/${PROJECT_NAME}" proj_len)
-        math(EXPR substr_len "${cur_src_len} - ${proj_len}")
-        string(SUBSTRING ${CMAKE_CURRENT_SOURCE_DIR} 0 ${substr_len} PARENT_DIR)
-        if(EXISTS ${CMAKE_SOURCE_DIR}/lib/${package})
-            message(STATUS 
-                "${PROJECT_NAME} found ${package} in ${CMAKE_SOURCE_DIR}/lib/")
-            set(${package}_INCLUDE_DIRS
-                ${CMAKE_SOURCE_DIR}/lib/${package}/include PARENT_SCOPE)
-        elseif(EXISTS ${PARENT_DIR}/lib/${package})
-            message(STATUS 
-                "${PROJECT_NAME} found ${package} in ${PARENT_DIR}/lib")
-            set(${package}_INCLUDE_DIRS
-                ${PARENT_DIR}/lib/${package}/include PARENT_SCOPE)
-        else()
-            message(STATUS 
-                "${PROJECT_NAME} could not find existing ${package} TARGET")
-        endif()
-    elseif(EXISTS ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        message(STATUS 
-            "${PROJECT_NAME} found ${package} in ${PROJECT_NAME}/lib/")
-        add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        set(${package}_INCLUDE_DIRS 
-            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
-    else()
-        message(STATUS "${PROJECT_NAME} did not find ${package}")
-        message(STATUS "cloning ${package} into local ${PROJECT_NAME}/lib/")
-        # Clone and create the proper variables
-        file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/lib)
-        execute_process(COMMAND 
-            git clone ${url} ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
-        set(${package}_INCLUDE_DIRS 
-            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
-    endif()
-endfunction()
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/findDeps.cmake)
 
 find_deps(geometry https://github.com/superjax/geometry)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(gnss_utils)
 
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -12,11 +13,20 @@ function(find_deps package url)
     if (${package}_FOUND)
         message(STATUS "${PROJECT_NAME} found package ${package}")
     elseif(TARGET ${package})
+        string(LENGTH ${CMAKE_CURRENT_SOURCE_DIR} cur_src_len)
+        string(LENGTH "/lib/${PROJECT_NAME}" proj_len)
+        math(EXPR substr_len "${cur_src_len} - ${proj_len}")
+        string(SUBSTRING ${CMAKE_CURRENT_SOURCE_DIR} 0 ${substr_len} PARENT_DIR)
         if(EXISTS ${CMAKE_SOURCE_DIR}/lib/${package})
             message(STATUS 
                 "${PROJECT_NAME} found ${package} in ${CMAKE_SOURCE_DIR}/lib/")
             set(${package}_INCLUDE_DIRS
                 ${CMAKE_SOURCE_DIR}/lib/${package}/include PARENT_SCOPE)
+        elseif(EXISTS ${PARENT_DIR}/lib/${package})
+            message(STATUS 
+                "${PROJECT_NAME} found ${package} in ${PARENT_DIR}/lib")
+            set(${package}_INCLUDE_DIRS
+                ${PARENT_DIR}/lib/${package}/include PARENT_SCOPE)
         else()
             message(STATUS 
                 "${PROJECT_NAME} could not find existing ${package} TARGET")

--- a/cmake/findDeps.cmake
+++ b/cmake/findDeps.cmake
@@ -1,0 +1,28 @@
+function(find_deps package url)
+    find_package(${package} QUIET)
+    if (${package}_FOUND)
+        message(STATUS "${PROJECT_NAME} found package ${package}")
+    elseif(TARGET ${package})
+        if(NOT ${package}_INCLUDE_DIRS STREQUAL "")
+            message(STATUS "${PROJECT_NAME} found ${package}_INCLUDE_DIRS")
+        elseif(EXISTS ${CMAKE_SOURCE_DIR}/lib/${package})
+            message(STATUS 
+                "${PROJECT_NAME} found ${package} in ${CMAKE_SOURCE_DIR}/lib/")
+            set(${package}_INCLUDE_DIRS
+                ${CMAKE_SOURCE_DIR}/lib/${package}/include PARENT_SCOPE)
+        else()
+            message(SEND_ERROR "${PROJECT_NAME} could't find ${package} TARGET")
+        endif()
+    else()
+        if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+            message(STATUS "${PROJECT_NAME} did not find ${package}")
+            file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/lib)
+            execute_process(COMMAND 
+                git clone ${url} ${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        endif()
+        message(STATUS "${PROJECT_NAME} is using local lib/${package}")
+        add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lib/${package})
+        set(${package}_INCLUDE_DIRS 
+            ${CMAKE_CURRENT_LIST_DIR}/lib/${package}/include PARENT_SCOPE)
+    endif()
+endfunction()


### PR DESCRIPTION
This fixes the cmake issues we were having as long as the root CMakeLists.txt has a lib/geometry. I check if geometry is already a target. If it is, I set geometry_INCLUDE_DIRS to be ${CMAKE_SOURCE_DIR}/lib/geometry.